### PR TITLE
Augment and strengthen tests for deprecation of edit parameter

### DIFF
--- a/traits/tests/test_configure_traits.py
+++ b/traits/tests/test_configure_traits.py
@@ -15,6 +15,7 @@ import shutil
 import tempfile
 import unittest
 import unittest.mock as mock
+import warnings
 
 from traits.api import HasTraits, Int
 from traits.testing.optional_dependencies import requires_traitsui, traitsui
@@ -130,13 +131,27 @@ class TestConfigureTraits(unittest.TestCase):
     def test_edit_when_false(self):
         # Check for deprecation warning when *edit* is false.
         model = Model()
-        with mock.patch.object(self.toolkit, "view_application"):
+        with mock.patch.object(self.toolkit, "view_application") as mock_view:
             with self.assertWarns(DeprecationWarning):
                 model.configure_traits(edit=False)
+        mock_view.assert_not_called()
 
     def test_edit_when_true(self):
         # Check for deprecation warning when *edit* is false.
         model = Model()
-        with mock.patch.object(self.toolkit, "view_application"):
+        with mock.patch.object(self.toolkit, "view_application") as mock_view:
+            mock_view.return_value = True
             with self.assertWarns(DeprecationWarning):
                 model.configure_traits(edit=True)
+        self.assertEqual(len(mock_view.mock_calls), 1)
+
+    def test_edit_not_given(self):
+        # Normal case where the *edit* argument is not supplied.
+        model = Model()
+        with mock.patch.object(self.toolkit, "view_application") as mock_view:
+            mock_view.return_value = True
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                warnings.simplefilter("always", DeprecationWarning)
+                model.configure_traits()
+        self.assertEqual(len(mock_view.mock_calls), 1)
+        self.assertEqual(len(captured_warnings), 0)


### PR DESCRIPTION
Hi @avats-dev. This is a PR against your branch that strengthens the tests slightly. This should make it easier to check that you have the correct logic in `configure_traits`. If you're okay with these changes, you can merge this PR into your branch.

In more detail:

- In the tests for `edit=False` and `edit=True`, we add checks that `view_application` is called the expected number of times. (That is, it shouldn't be called when `edit=False`, and it should be called once when `edit=True`.)
- There's an extra test for the common case of the user not passing `edit` at all. In this case, `view_application` should still be called, and the test checks explicitly that no `DeprecationWarning` is issued.